### PR TITLE
feat : 채팅방 CRUD API 구현

### DIFF
--- a/src/main/kotlin/com/meow/meowchatting/chat/command/domain/Room.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/domain/Room.java
@@ -1,6 +1,8 @@
 package com.meow.meowchatting.chat.command.domain;
 
 import com.meow.meowchatting.chat.command.enums.RoomType;
+import com.meow.meowchatting.common.base.AbstractBaseUserByEntity;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -23,12 +25,8 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "deleted_at IS NULL")
-public class Room {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "room_id", nullable = false, updatable = false)
-    private Long roomId;
+@AttributeOverride(name = "id", column = @Column(name = "room_id"))
+public class Room extends AbstractBaseUserByEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "room_type", nullable = false, length = 10)
@@ -40,14 +38,6 @@ public class Room {
     @Column(name = "room_owner_user_id", nullable = false)
     private Long roomOwnerUserId;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private LocalDateTime modifiedAt;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
 
     @Builder
     public Room(RoomType roomType, String roomName, Long roomOwnerUserId) {
@@ -56,23 +46,12 @@ public class Room {
         this.roomOwnerUserId = roomOwnerUserId;
     }
 
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.modifiedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.modifiedAt = LocalDateTime.now();
-    }
-
     public void updateRoomName(String roomName) {
         this.roomName = roomName;
     }
 
     public void deleteRoom() {
-        this.deletedAt = LocalDateTime.now();
+        setDeletedAt(LocalDateTime.now());
     }
 
 }

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/domain/Room.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/domain/Room.java
@@ -1,0 +1,78 @@
+package com.meow.meowchatting.chat.command.domain;
+
+import com.meow.meowchatting.chat.command.enums.RoomType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Table(name = "room")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted_at IS NULL")
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_id", nullable = false, updatable = false)
+    private Long roomId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "room_type", nullable = false, length = 10)
+    private RoomType roomType;
+
+    @Column(name = "room_name", nullable = false, length = 100)
+    private String roomName;
+
+    @Column(name = "room_owner_user_id", nullable = false)
+    private Long roomOwnerUserId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public Room(RoomType roomType, String roomName, Long roomOwnerUserId) {
+        this.roomType = roomType;
+        this.roomName = roomName;
+        this.roomOwnerUserId = roomOwnerUserId;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+    public void updateRoomName(String roomName) {
+        this.roomName = roomName;
+    }
+
+    public void deleteRoom() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/domain/RoomUsers.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/domain/RoomUsers.java
@@ -1,0 +1,81 @@
+package com.meow.meowchatting.chat.command.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "room_users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uniq_room_users", columnNames = {"room_id", "user_id"})
+        },
+        indexes = {
+                @Index(name = "idx_user_id", columnList = "user_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted_at IS NULL")
+public class RoomUsers {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_users_id", nullable = false, updatable = false)
+    private Long roomUsersId;
+
+    @Column(name = "room_id", nullable = false)
+    private Long roomId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "is_active", nullable = true)
+    private Boolean isActive;
+
+    @Column(name = "last_read_message_id")
+    private Long lastReadMessageId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public RoomUsers(Long roomId, Long userId, Boolean isActive, Long lastReadMessageId) {
+        this.roomId = roomId;
+        this.userId = userId;
+        this.isActive = isActive != null ? isActive : true;
+        this.lastReadMessageId = lastReadMessageId;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+    public void updateLastReadMessageId(Long lastReadMessageId) {
+        this.lastReadMessageId = lastReadMessageId;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/domain/error/RoomResponseCode.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/domain/error/RoomResponseCode.java
@@ -1,0 +1,27 @@
+package com.meow.meowchatting.chat.command.domain.error;
+
+import com.meow.meowchatting.common.exception.MeowCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum RoomResponseCode implements MeowCode {
+
+    SUCCESS("정상 처리 완료", HttpStatus.OK),
+
+    NOT_FOUND("존재하지 않는 채팅방입니다.", HttpStatus.NOT_FOUND),
+
+    INVALID_ROOM_TYPE("지원하지 않는 채팅방 타입입니다.", HttpStatus.BAD_REQUEST),
+
+    INVALID_OWNER("채팅방 소유자만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN);
+
+    private final String responseMessage;
+
+    private final HttpStatus httpStatus;
+
+    RoomResponseCode(String responseMessage, HttpStatus httpStatus) {
+        this.responseMessage = responseMessage;
+        this.httpStatus = httpStatus;
+    }
+
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/dto/ChatRoomCreateRequest.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/dto/ChatRoomCreateRequest.java
@@ -1,0 +1,40 @@
+package com.meow.meowchatting.chat.command.dto;
+
+import com.meow.meowchatting.chat.command.enums.RoomType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ChatRoomCreateRequest {
+
+    @NotNull(message = "채팅방 타입은 필수입니다.")
+    private RoomType roomType;
+
+    @NotBlank(message = "채팅방 이름은 필수입니다.")
+    @Length(max = 100, message = "채팅방 이름은 최대 100자 이하입니다.")
+    private String roomName;
+
+    @Valid
+    @NotNull(message = "채팅방 멤버는 필수입니다.")
+    private List<MemberInfo> members;
+
+    @Getter
+    @NoArgsConstructor
+    public static class MemberInfo {
+
+        @NotNull(message = "사용자 ID는 필수입니다.")
+        private Long userId;
+
+        @NotBlank(message = "사용자 이름은 필수입니다.")
+        private String userName;
+
+        private String profileUrl;
+    }
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/dto/ChatRoomCreateResponse.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/dto/ChatRoomCreateResponse.java
@@ -1,0 +1,61 @@
+package com.meow.meowchatting.chat.command.dto;
+
+import com.meow.meowchatting.chat.command.enums.RoomType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ChatRoomCreateResponse {
+
+    private Long roomId;
+    private RoomType roomType;
+    private String roomName;
+    private String previewMessage;
+    private Integer unreadMessageCount;
+    private String createdFormatted;
+    private List<MemberInfo> members;
+
+    @Builder
+    public ChatRoomCreateResponse(Long roomId, RoomType roomType, String roomName,
+                                   String previewMessage, Integer unreadMessageCount,
+                                   String createdFormatted, List<MemberInfo> members) {
+        this.roomId = roomId;
+        this.roomType = roomType;
+        this.roomName = roomName;
+        this.previewMessage = previewMessage;
+        this.unreadMessageCount = unreadMessageCount;
+        this.createdFormatted = createdFormatted;
+        this.members = members;
+    }
+
+    @Getter
+    @Builder
+    public static class MemberInfo {
+        private Long userId;
+        private String userName;
+        private String profileUrl;
+
+        public MemberInfo(Long userId, String userName, String profileUrl) {
+            this.userId = userId;
+            this.userName = userName;
+            this.profileUrl = profileUrl;
+        }
+    }
+
+    public static ChatRoomCreateResponse of(Long roomId, RoomType roomType, String roomName,
+                                             String createdFormatted, List<MemberInfo> members) {
+        StringBuilder previewMessageBuilder = new StringBuilder();
+        members.forEach(it-> previewMessageBuilder.append(it.userName).append("/") );
+        return ChatRoomCreateResponse.builder()
+                .roomId(roomId)
+                .roomType(roomType)
+                .roomName(roomName)
+                .previewMessage(previewMessageBuilder.toString())
+                .unreadMessageCount(0)
+                .createdFormatted(createdFormatted)
+                .members(members)
+                .build();
+    }
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/enums/RoomType.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/enums/RoomType.java
@@ -1,0 +1,6 @@
+package com.meow.meowchatting.chat.command.enums;
+
+public enum RoomType {
+    DIRECT,
+    GROUP
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/repository/RoomCommandRepository.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/repository/RoomCommandRepository.java
@@ -1,0 +1,7 @@
+package com.meow.meowchatting.chat.command.repository;
+
+import com.meow.meowchatting.chat.command.domain.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomCommandRepository extends JpaRepository<Room, Long> {
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/repository/RoomUsersRepository.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/repository/RoomUsersRepository.java
@@ -1,0 +1,7 @@
+package com.meow.meowchatting.chat.command.repository;
+
+import com.meow.meowchatting.chat.command.domain.RoomUsers;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomUsersRepository extends JpaRepository<RoomUsers, Long> {
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/service/ChatRoomCreateService.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/service/ChatRoomCreateService.java
@@ -1,0 +1,89 @@
+package com.meow.meowchatting.chat.command.service;
+
+import com.meow.meowchatting.chat.command.dto.ChatRoomCreateRequest;
+import com.meow.meowchatting.chat.command.dto.ChatRoomCreateResponse;
+import com.meow.meowchatting.chat.command.repository.RoomCommandRepository;
+import com.meow.meowchatting.chat.command.repository.RoomUsersRepository;
+import com.meow.meowchatting.chat.command.domain.Room;
+import com.meow.meowchatting.chat.command.domain.RoomUsers;
+import com.meow.meowchatting.chat.command.domain.error.RoomResponseCode;
+import com.meow.meowchatting.common.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatRoomCreateService {
+
+    private final RoomCommandRepository roomCommandRepository;
+    private final RoomUsersRepository roomUsersRepository;
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("a h:mm");
+
+    /**
+     * 채팅방 생성 (DIRECT, GROUP 타입 모두 처리)
+     */
+    public DataResponse<ChatRoomCreateResponse> createChatRoom(Long userId, ChatRoomCreateRequest request) {
+        // Room 엔티티 생성 및 저장
+        Room room = Room.builder()
+                .roomType(request.getRoomType())
+                .roomName(request.getRoomName())
+                .roomOwnerUserId(userId)
+                .build();
+
+        Room savedRoom = roomCommandRepository.save(room);
+
+        // RoomUsers 저장 (방 생성자 포함)
+        RoomUsers ownerRoomUser = RoomUsers.builder()
+                .roomId(savedRoom.getRoomId())
+                .userId(userId)
+                .isActive(true)
+                .build();
+        roomUsersRepository.save(ownerRoomUser);
+
+        // 멤버들 RoomUsers 저장
+        request.getMembers().forEach(member -> {
+            RoomUsers roomUser = RoomUsers.builder()
+                    .roomId(savedRoom.getRoomId())
+                    .userId(member.getUserId())
+                    .isActive(true)
+                    .build();
+            roomUsersRepository.save(roomUser);
+        });
+
+        // Response DTO 생성
+        List<ChatRoomCreateResponse.MemberInfo> members = request.getMembers().stream()
+                .map(member -> ChatRoomCreateResponse.MemberInfo.builder()
+                        .userId(member.getUserId())
+                        .userName(member.getUserName())
+                        .profileUrl(member.getProfileUrl())
+                        .build())
+                .collect(Collectors.toList());
+
+        String createdFormatted = formatCreatedAt(savedRoom.getCreatedAt());
+
+        ChatRoomCreateResponse response = ChatRoomCreateResponse.of(
+                savedRoom.getRoomId(),
+                savedRoom.getRoomType(),
+                savedRoom.getRoomName(),
+                createdFormatted,
+                members
+        );
+
+        return new DataResponse<>(RoomResponseCode.SUCCESS, response);
+    }
+
+    /**
+     * 생성 시간을 "오전 10:22" 형식으로 포맷팅
+     */
+    private String formatCreatedAt(LocalDateTime createdAt) {
+        return createdAt.format(TIME_FORMATTER);
+    }
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/service/ChatRoomCreateService.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/service/ChatRoomCreateService.java
@@ -42,7 +42,7 @@ public class ChatRoomCreateService {
 
         // RoomUsers 저장 (방 생성자 포함)
         RoomUsers ownerRoomUser = RoomUsers.builder()
-                .roomId(savedRoom.getRoomId())
+                .roomId(savedRoom.getId())
                 .userId(userId)
                 .isActive(true)
                 .build();
@@ -51,7 +51,7 @@ public class ChatRoomCreateService {
         // 멤버들 RoomUsers 저장
         request.getMembers().forEach(member -> {
             RoomUsers roomUser = RoomUsers.builder()
-                    .roomId(savedRoom.getRoomId())
+                    .roomId(savedRoom.getId())
                     .userId(member.getUserId())
                     .isActive(true)
                     .build();
@@ -70,7 +70,7 @@ public class ChatRoomCreateService {
         String createdFormatted = formatCreatedAt(savedRoom.getCreatedAt());
 
         ChatRoomCreateResponse response = ChatRoomCreateResponse.of(
-                savedRoom.getRoomId(),
+                savedRoom.getId(),
                 savedRoom.getRoomType(),
                 savedRoom.getRoomName(),
                 createdFormatted,

--- a/src/main/kotlin/com/meow/meowchatting/chat/command/service/ChatRoomDeleteService.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/command/service/ChatRoomDeleteService.java
@@ -1,0 +1,36 @@
+package com.meow.meowchatting.chat.command.service;
+
+import com.meow.meowchatting.chat.command.domain.Room;
+import com.meow.meowchatting.chat.command.domain.error.RoomResponseCode;
+import com.meow.meowchatting.chat.command.repository.RoomCommandRepository;
+import com.meow.meowchatting.common.exception.MeowException;
+import com.meow.meowchatting.common.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatRoomDeleteService {
+
+    private final RoomCommandRepository roomCommandRepository;
+
+    /**
+     * 채팅방 삭제
+     */
+    public DataResponse<Void> deleteChatRoom(Long userId, Long roomId) {
+        Room room = roomCommandRepository.findById(roomId)
+                .orElseThrow(() -> new MeowException(RoomResponseCode.NOT_FOUND));
+
+        if (!Objects.equals(room.getRoomOwnerUserId(), userId)) {
+            throw new MeowException(RoomResponseCode.INVALID_OWNER);
+        }
+
+        room.deleteRoom();
+        return new DataResponse<>(RoomResponseCode.SUCCESS);
+    }
+
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/controller/ChatRoomController.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/controller/ChatRoomController.java
@@ -1,0 +1,42 @@
+package com.meow.meowchatting.chat.controller;
+
+import com.meow.meowchatting.chat.command.dto.ChatRoomCreateRequest;
+import com.meow.meowchatting.chat.command.dto.ChatRoomCreateResponse;
+import com.meow.meowchatting.chat.command.service.ChatRoomCreateService;
+import com.meow.meowchatting.chat.command.service.ChatRoomDeleteService;
+import com.meow.meowchatting.common.annotation.CurrentUser;
+import com.meow.meowchatting.common.response.DataResponse;
+import com.meow.meowchatting.user.command.domain.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final ChatRoomCreateService chatRoomCreateService;
+    private final ChatRoomDeleteService chatRoomDeleteService;
+
+    @PostMapping("/chat/rooms")
+    public DataResponse<ChatRoomCreateResponse> createChatRoom(
+            @CurrentUser UserPrincipal userPrincipal,
+            @Valid @RequestBody ChatRoomCreateRequest request) {
+
+        return chatRoomCreateService.createChatRoom(userPrincipal.getUser().getId(), request);
+    }
+
+    @DeleteMapping("/user/chat/rooms/{roomId}")
+    public DataResponse<Void> deleteChatRoom(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long roomId) {
+
+        return chatRoomDeleteService.deleteChatRoom(userPrincipal.getUser().getId(), roomId);
+    }
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/controller/ChatRoomQueryController.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/controller/ChatRoomQueryController.java
@@ -1,0 +1,37 @@
+package com.meow.meowchatting.chat.controller;
+
+import com.meow.meowchatting.chat.query.dto.ChatRoomListResponse;
+import com.meow.meowchatting.chat.query.service.ChatRoomQueryService;
+import com.meow.meowchatting.common.annotation.CurrentUser;
+import com.meow.meowchatting.common.dto.PagingRequest;
+import com.meow.meowchatting.common.response.DataResponse;
+import com.meow.meowchatting.user.command.domain.UserPrincipal;
+import jakarta.validation.constraints.Min;
+import org.springframework.data.domain.Page;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping(value = "/api/v1/user/chat/rooms", name = "채팅방 Query 컨트롤러")
+public class ChatRoomQueryController {
+
+    private final ChatRoomQueryService chatRoomQueryService;
+
+    public ChatRoomQueryController(ChatRoomQueryService chatRoomQueryService) {
+        this.chatRoomQueryService = chatRoomQueryService;
+    }
+
+    @GetMapping(name = "채팅방 목록 조회")
+    public DataResponse<Page<ChatRoomListResponse>> chatRoomList(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam @Min(value = 1, message = "페이지는 최소 1 이상입니다.") int page,
+            @RequestParam @Min(value = 1, message = "데이터 수는 최소 1 이상입니다.") int size) {
+        PagingRequest request = PagingRequest.of(page, size);
+        return chatRoomQueryService.chatRoomList(userPrincipal.getUser().getId(), request);
+    }
+
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/query/dto/ChatRoomListResponse.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/query/dto/ChatRoomListResponse.java
@@ -1,0 +1,28 @@
+package com.meow.meowchatting.chat.query.dto;
+
+import com.meow.meowchatting.chat.command.enums.RoomType;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ChatRoomListResponse {
+
+    private Long roomId;
+    private RoomType roomType;
+    private String roomName;
+    private Long roomOwnerUserId;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    @QueryProjection
+    public ChatRoomListResponse(Long roomId, RoomType roomType, String roomName, Long roomOwnerUserId, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.roomId = roomId;
+        this.roomType = roomType;
+        this.roomName = roomName;
+        this.roomOwnerUserId = roomOwnerUserId;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/query/repository/RoomPagedQueryRepository.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/query/repository/RoomPagedQueryRepository.java
@@ -1,0 +1,11 @@
+package com.meow.meowchatting.chat.query.repository;
+
+import com.meow.meowchatting.chat.query.dto.ChatRoomListResponse;
+import com.meow.meowchatting.common.dto.PagingRequest;
+import org.springframework.data.domain.Page;
+
+public interface RoomPagedQueryRepository {
+
+    Page<ChatRoomListResponse> pagedChatRoomList(Long userId, PagingRequest request);
+
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/query/repository/RoomQueryRepositoryImpl.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/query/repository/RoomQueryRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.meow.meowchatting.chat.query.repository;
+
+import com.meow.meowchatting.chat.command.domain.QRoom;
+import com.meow.meowchatting.chat.command.domain.QRoomUsers;
+import com.meow.meowchatting.chat.query.dto.ChatRoomListResponse;
+import com.meow.meowchatting.common.dto.PagingRequest;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class RoomQueryRepositoryImpl implements RoomPagedQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QRoom room = QRoom.room;
+    private final QRoomUsers roomUsers = QRoomUsers.roomUsers;
+
+    public RoomQueryRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    /**
+     * 채팅방 목록 조회
+     */
+    @Override
+    public Page<ChatRoomListResponse> pagedChatRoomList(Long userId, PagingRequest request) {
+        Pageable paging = PageRequest.of(request.getPage() - 1, request.getSize());
+
+        List<ChatRoomListResponse> result = queryFactory
+                .select(Projections.constructor(ChatRoomListResponse.class,
+                        room.roomId, room.roomType, room.roomName, room.roomOwnerUserId, room.createdAt, room.modifiedAt))
+                .from(roomUsers)
+                .innerJoin(room).on(roomUsers.roomId.eq(room.roomId))
+                .where(roomUsers.userId.eq(userId))
+                .orderBy(room.modifiedAt.desc())
+                .offset(paging.getOffset())
+                .limit(paging.getPageSize())
+                .fetch();
+
+        Long total = Optional.ofNullable(queryFactory
+                .select(roomUsers.countDistinct())
+                .from(roomUsers)
+                .innerJoin(room).on(roomUsers.roomId.eq(room.roomId))
+                .where(roomUsers.userId.eq(userId))
+                .fetchOne()).orElse(0L);
+
+        return new PageImpl<>(result, paging, total);
+    }
+}

--- a/src/main/kotlin/com/meow/meowchatting/chat/query/repository/RoomQueryRepositoryImpl.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/query/repository/RoomQueryRepositoryImpl.java
@@ -36,9 +36,9 @@ public class RoomQueryRepositoryImpl implements RoomPagedQueryRepository {
 
         List<ChatRoomListResponse> result = queryFactory
                 .select(Projections.constructor(ChatRoomListResponse.class,
-                        room.roomId, room.roomType, room.roomName, room.roomOwnerUserId, room.createdAt, room.modifiedAt))
+                        room.id, room.roomType, room.roomName, room.roomOwnerUserId, room.createdAt, room.modifiedAt))
                 .from(roomUsers)
-                .innerJoin(room).on(roomUsers.roomId.eq(room.roomId))
+                .innerJoin(room).on(roomUsers.roomId.eq(room.id))
                 .where(roomUsers.userId.eq(userId))
                 .orderBy(room.modifiedAt.desc())
                 .offset(paging.getOffset())
@@ -48,7 +48,7 @@ public class RoomQueryRepositoryImpl implements RoomPagedQueryRepository {
         Long total = Optional.ofNullable(queryFactory
                 .select(roomUsers.countDistinct())
                 .from(roomUsers)
-                .innerJoin(room).on(roomUsers.roomId.eq(room.roomId))
+                .innerJoin(room).on(roomUsers.roomId.eq(room.id))
                 .where(roomUsers.userId.eq(userId))
                 .fetchOne()).orElse(0L);
 

--- a/src/main/kotlin/com/meow/meowchatting/chat/query/service/ChatRoomQueryService.java
+++ b/src/main/kotlin/com/meow/meowchatting/chat/query/service/ChatRoomQueryService.java
@@ -1,0 +1,30 @@
+package com.meow.meowchatting.chat.query.service;
+
+import com.meow.meowchatting.chat.command.domain.error.RoomResponseCode;
+import com.meow.meowchatting.chat.query.dto.ChatRoomListResponse;
+import com.meow.meowchatting.chat.query.repository.RoomPagedQueryRepository;
+import com.meow.meowchatting.common.dto.PagingRequest;
+import com.meow.meowchatting.common.response.DataResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ChatRoomQueryService {
+
+    private final RoomPagedQueryRepository roomPagedQueryRepository;
+
+    public ChatRoomQueryService(RoomPagedQueryRepository roomPagedQueryRepository) {
+        this.roomPagedQueryRepository = roomPagedQueryRepository;
+    }
+
+    /**
+     * 채팅방 목록 조회
+     */
+    public DataResponse<Page<ChatRoomListResponse>> chatRoomList(Long userId, PagingRequest request) {
+        Page<ChatRoomListResponse> chatRoomList = roomPagedQueryRepository.pagedChatRoomList(userId, request);
+        return new DataResponse<>(RoomResponseCode.SUCCESS, chatRoomList);
+    }
+
+}

--- a/src/main/resources/db/migration/V20250917221235__create_romm_table.sql
+++ b/src/main/resources/db/migration/V20250917221235__create_romm_table.sql
@@ -5,10 +5,9 @@ CREATE TABLE room
     room_type          ENUM('DIRECT', 'GROUP') NOT NULL COMMENT '채팅방 타입(1:1, 그룹)',
     room_name          VARCHAR(100) NOT NULL COMMENT '채팅방 이름',
     room_owner_user_id BIGINT UNSIGNED NOT NULL COMMENT '채팅방 생성자 ID',
-
-		created_at         DATETIME(6) NOT NULL COMMENT '생성일',
-		modified_at        DATETIME(6) NOT NULL COMMENT '수정일',
-		deleted_at         DATETIME(6) NOT NULL COMMENT '삭제일'
+    created_at         DATETIME(6) NOT NULL COMMENT '생성일',
+    modified_at        DATETIME(6) NOT NULL COMMENT '수정일',
+    deleted_at         DATETIME(6) NOT NULL COMMENT '삭제일'
 ) ENGINE = InnoDB
   CHARACTER SET utf8mb4
   COLLATE utf8mb4_unicode_ci

--- a/src/main/resources/db/migration/V20250917221307__create_room_users_table.sql
+++ b/src/main/resources/db/migration/V20250917221307__create_room_users_table.sql
@@ -6,13 +6,12 @@ CREATE TABLE room_users
     user_id              BIGINT UNSIGNED NOT NULL COMMENT '사용자 ID',
     is_active            BOOLEAN NULL DEFAULT TRUE COMMENT '채팅방 활성화 여부',
     last_read_message_id BIGINT UNSIGNED NULL COMMENT '마지막 읽은 메시지 ID',
+    created_at           DATETIME(6) NOT NULL COMMENT '생성일',
+    modified_at          DATETIME(6) NOT NULL COMMENT '수정일',
+    deleted_at           DATETIME(6) NOT NULL COMMENT '삭제일',
 
-		created_at           DATETIME(6) NOT NULL COMMENT '생성일',
-		modified_at          DATETIME(6) NOT NULL COMMENT '수정일',
-		deleted_at           DATETIME(6) NOT NULL COMMENT '삭제일',
-
-		UNIQUE KEY           uniq_room_users (room_id, user_id),
-		INDEX                idx_user_id (user_id) COMMENT '유저 ID index'
+    UNIQUE KEY uniq_room_users (room_id, user_id),
+    INDEX                idx_user_id (user_id) COMMENT '유저 ID index'
 ) ENGINE = InnoDB
   CHARACTER SET utf8mb4
   COLLATE utf8mb4_unicode_ci


### PR DESCRIPTION
- 채팅방 생성 API (POST /api/v1/chat/rooms)
- 채팅방 목록 조회 API (GET /api/v1/user/chat/rooms)
- 채팅방 삭제 API (DELETE /api/v1/user/chat/rooms/{roomId})

주요 구현 사항:
- Room, RoomUsers 엔티티 추가
- QueryDSL을 활용한 페이징 처리
- Soft delete 방식으로 채팅방 삭제 처리
- 채팅방 소유자 권한 검증 로직 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)